### PR TITLE
Fix build with GCC 15

### DIFF
--- a/third-party/json11/json11.cpp
+++ b/third-party/json11/json11.cpp
@@ -24,6 +24,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <cstdio>
+#include <cstdint>
 #include <limits>
 
 namespace json11 {


### PR DESCRIPTION
GCC 15 has removed the stdint header file from commonly used headers.

This fixes the issue