### PR TITLE
Build improvements: clang-tidy and ccache

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,16 @@
+---
+Checks: >
+  readability-*,
+  performance-*,
+  clang-analyzer-*,
+  modernize-*,
+  -clang-analyzer-security.insecureAPI.strcpy,
+  -readability-magic-numbers,
+  -readability-function-cognitive-complexity,
+  -google-*
+
+WarningsAsErrors: '*'
+
+HeaderFilterRegex: '^(?!.*/build.*/lvgl).*(/home/alex/cuckoo_nest/src/.*\.(hpp?|cpp))$'
+
+FormatStyle: none

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -11,6 +11,6 @@ Checks: >
 
 WarningsAsErrors: '*'
 
-HeaderFilterRegex: '^(?!.*/build.*/lvgl).*(/home/alex/cuckoo_nest/src/.*\.(hpp?|cpp))$'
+HeaderFilterRegex: '^(?!.*/build.*/lvgl|.*/json11).*(.*\.(hpp?|cpp))$'
 
 FormatStyle: none

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -32,8 +32,11 @@ jobs:
     - name: Get cmake version
       run: cmake --version
 
+    - name: Install clang-tools
+      run: sudo apt-get install -y clang-tools
+
     - name: Configure tests
-      run: cmake -G "Unix Makefiles" -B ${{github.workspace}}/build_tests -DCMAKE_TOOLCHAIN_FILE=../cmake/host-toolchain.cmake
+      run: cmake -G "Unix Makefiles" -B ${{github.workspace}}/build_tests -DCMAKE_TOOLCHAIN_FILE=../cmake/host-toolchain.cmake -DENABLE_CLANG_TIDY=ON
 
     - name: Build tests
       # Build your program with the given configuration
@@ -53,7 +56,7 @@ jobs:
           ${{github.workspace}}/build/test-results.xml
 
     - name: Configure arm build
-      run: cmake -G "Unix Makefiles" -B ${{github.workspace}}/build -DCMAKE_TOOLCHAIN_FILE=./cmake/arm-toolchain.cmake -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCUCKOO_VERSION=${{ github.sha }}
+      run: cmake -G "Unix Makefiles" -B ${{github.workspace}}/build -DCMAKE_TOOLCHAIN_FILE=./cmake/arm-toolchain.cmake -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCUCKOO_VERSION=${{ github.sha }} -DENABLE_CLANG_TIDY=ON
 
     - name: Build arm binary
       run: cmake --build ${{github.workspace}}/build -- VERBOSE=1

--- a/.github/workflows/pull-request-action.yml
+++ b/.github/workflows/pull-request-action.yml
@@ -39,7 +39,25 @@ jobs:
         brew install curl sdl2
         # Set environment variables for SDL2 on macOS
         echo "SDL2_DIR=$(brew --prefix sdl2)" >> $GITHUB_ENV
-        echo "PKG_CONFIG_PATH=$(brew --prefix sdl2)/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV 
+        echo "PKG_CONFIG_PATH=$(brew --prefix sdl2)/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
+
+    - name: Debug SDL2 installation (macOS)
+      if: runner.os == 'macOS'
+      run: |
+        echo "SDL2 installation directory:"
+        brew --prefix sdl2
+        echo ""
+        echo "SDL2 include files:"
+        ls -la $(brew --prefix sdl2)/include/
+        echo ""
+        echo "SDL2 lib files:"
+        ls -la $(brew --prefix sdl2)/lib/
+        echo ""
+        echo "PKG_CONFIG_PATH:"
+        echo $PKG_CONFIG_PATH
+        echo ""
+        echo "pkg-config SDL2:"
+        pkg-config --cflags --libs sdl2 || echo "pkg-config SDL2 not found" 
     
     - name: Get cmake version
       run: cmake --version
@@ -51,9 +69,11 @@ jobs:
         CMAKE_ARGS="-DCMAKE_TOOLCHAIN_FILE=../cmake/host-toolchain.cmake -DENABLE_CLANG_TIDY=${{ runner.os == 'Linux' && 'ON' || 'OFF' }}"
         if [ "${{ runner.os }}" = "macOS" ]; then
           SDL2_PREFIX=$(brew --prefix sdl2)
+          echo "Using SDL2_PREFIX: $SDL2_PREFIX"
           CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_PREFIX_PATH=$SDL2_PREFIX -DSDL2_INCLUDE_DIR=$SDL2_PREFIX/include/SDL2 -DSDL2_LIBRARY=$SDL2_PREFIX/lib/libSDL2.dylib"
         fi
-        cmake -G "Unix Makefiles" -B ${{github.workspace}}/build $CMAKE_ARGS
+        echo "CMAKE_ARGS: $CMAKE_ARGS"
+        cmake -G "Unix Makefiles" -B ${{github.workspace}}/build $CMAKE_ARGS --debug-output
 
     - name: Build
       # Build your program with the given configuration

--- a/.github/workflows/pull-request-action.yml
+++ b/.github/workflows/pull-request-action.yml
@@ -99,8 +99,10 @@ jobs:
       run: ctest --output-junit test-results.xml
     
     - name: Publish Test Results
-      uses: EnricoMi/publish-unit-test-result-action@v2
+      uses: dorny/test-reporter@v1
       if: (!cancelled())
       with:
-        files: |
-          ${{github.workspace}}/build/test-results.xml
+        name: Test Results (${{ matrix.os }})
+        path: ${{github.workspace}}/build/test-results.xml
+        reporter: java-junit
+        fail-on-error: true

--- a/.github/workflows/pull-request-action.yml
+++ b/.github/workflows/pull-request-action.yml
@@ -43,7 +43,12 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -G "Unix Makefiles" -B ${{github.workspace}}/build -DCMAKE_TOOLCHAIN_FILE=../cmake/host-toolchain.cmake -DENABLE_CLANG_TIDY=${{ runner.os == 'Linux' && 'ON' || 'OFF' }}
+      run: |
+        CMAKE_ARGS="-DCMAKE_TOOLCHAIN_FILE=../cmake/host-toolchain.cmake -DENABLE_CLANG_TIDY=${{ runner.os == 'Linux' && 'ON' || 'OFF' }}"
+        if [ "${{ runner.os }}" = "macOS" ]; then
+          CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_PREFIX_PATH=$(brew --prefix sdl2)"
+        fi
+        cmake -G "Unix Makefiles" -B ${{github.workspace}}/build $CMAKE_ARGS
 
     - name: Build
       # Build your program with the given configuration

--- a/.github/workflows/pull-request-action.yml
+++ b/.github/workflows/pull-request-action.yml
@@ -70,10 +70,13 @@ jobs:
         if [ "${{ runner.os }}" = "macOS" ]; then
           SDL2_PREFIX=$(brew --prefix sdl2)
           echo "Using SDL2_PREFIX: $SDL2_PREFIX"
-          CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_PREFIX_PATH=$SDL2_PREFIX -DSDL2_INCLUDE_DIR=$SDL2_PREFIX/include/SDL2 -DSDL2_LIBRARY=$SDL2_PREFIX/lib/libSDL2.dylib"
+          # Set include dir to parent of SDL2 so #include <SDL2/SDL.h> works
+          CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_PREFIX_PATH=$SDL2_PREFIX -DSDL2_INCLUDE_DIR=$SDL2_PREFIX/include -DSDL2_LIBRARY=$SDL2_PREFIX/lib/libSDL2.dylib"
+          # Also pass SDL2 flags to C compiler for external projects like LVGL
+          CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_C_FLAGS='-I$SDL2_PREFIX/include'"
         fi
         echo "CMAKE_ARGS: $CMAKE_ARGS"
-        cmake -G "Unix Makefiles" -B ${{github.workspace}}/build $CMAKE_ARGS --debug-output
+        cmake -G "Unix Makefiles" -B ${{github.workspace}}/build $CMAKE_ARGS
 
     - name: Build
       # Build your program with the given configuration

--- a/.github/workflows/pull-request-action.yml
+++ b/.github/workflows/pull-request-action.yml
@@ -29,7 +29,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install Ubuntu dependencies
-      run: sudo apt-get install -y libcurl4-openssl-dev libsdl2-dev
+      run: sudo apt-get install -y libcurl4-openssl-dev libsdl2-dev clang-tools
     
     - name: Get cmake version
       run: cmake --version
@@ -42,6 +42,12 @@ jobs:
     - name: Build
       # Build your program with the given configuration
       run: cmake --build ${{github.workspace}}/build
+
+    - name: Run clang-tidy static analysis
+      working-directory: ${{github.workspace}}/build
+      # clang-tidy is automatically invoked during build via CMAKE_CXX_CLANG_TIDY
+      # If any issues are found with --warnings-as-errors, the build will fail
+      run: echo "clang-tidy checks completed during build step"
 
     - name: Test
       working-directory: ${{github.workspace}}/build

--- a/.github/workflows/pull-request-action.yml
+++ b/.github/workflows/pull-request-action.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Install dependencies (macOS)
       if: runner.os == 'macOS'
       run: |
-        brew install curl sdl2
+        brew install curl sdl2 llvm
         # Set environment variables for SDL2 on macOS
         SDL2_PREFIX=$(brew --prefix sdl2)
         echo "SDL2_DIR=$SDL2_PREFIX" >> $GITHUB_ENV
@@ -45,6 +45,8 @@ jobs:
         echo "CXXFLAGS=-I$SDL2_PREFIX/include" >> $GITHUB_ENV
         echo "C_INCLUDE_PATH=$SDL2_PREFIX/include:$C_INCLUDE_PATH" >> $GITHUB_ENV
         echo "PKG_CONFIG_PATH=$(brew --prefix sdl2)/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
+        # Add LLVM to PATH for clang-tidy
+        echo "$(brew --prefix llvm)/bin" >> $GITHUB_PATH
 
     - name: Debug SDL2 installation (macOS)
       if: runner.os == 'macOS'
@@ -71,7 +73,7 @@ jobs:
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: |
-        CMAKE_ARGS="-DCMAKE_TOOLCHAIN_FILE=../cmake/host-toolchain.cmake -DENABLE_CLANG_TIDY=${{ runner.os == 'Linux' && 'ON' || 'OFF' }}"
+        CMAKE_ARGS="-DCMAKE_TOOLCHAIN_FILE=../cmake/host-toolchain.cmake -DENABLE_CLANG_TIDY=ON"
         if [ "${{ runner.os }}" = "macOS" ]; then
           SDL2_PREFIX=$(brew --prefix sdl2)
           echo "Using SDL2_PREFIX: $SDL2_PREFIX"
@@ -86,7 +88,6 @@ jobs:
       run: cmake --build ${{github.workspace}}/build
 
     - name: Run clang-tidy static analysis
-      if: runner.os == 'Linux'
       working-directory: ${{github.workspace}}/build
       # clang-tidy is automatically invoked during build via CMAKE_CXX_CLANG_TIDY
       # If any issues are found with --warnings-as-errors, the build will fail

--- a/.github/workflows/pull-request-action.yml
+++ b/.github/workflows/pull-request-action.yml
@@ -35,7 +35,11 @@ jobs:
 
     - name: Install dependencies (macOS)
       if: runner.os == 'macOS'
-      run: brew install curl sdl2 
+      run: |
+        brew install curl sdl2
+        # Set environment variables for SDL2 on macOS
+        echo "SDL2_DIR=$(brew --prefix sdl2)" >> $GITHUB_ENV
+        echo "PKG_CONFIG_PATH=$(brew --prefix sdl2)/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV 
     
     - name: Get cmake version
       run: cmake --version
@@ -46,7 +50,8 @@ jobs:
       run: |
         CMAKE_ARGS="-DCMAKE_TOOLCHAIN_FILE=../cmake/host-toolchain.cmake -DENABLE_CLANG_TIDY=${{ runner.os == 'Linux' && 'ON' || 'OFF' }}"
         if [ "${{ runner.os }}" = "macOS" ]; then
-          CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_PREFIX_PATH=$(brew --prefix sdl2)"
+          SDL2_PREFIX=$(brew --prefix sdl2)
+          CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_PREFIX_PATH=$SDL2_PREFIX -DSDL2_INCLUDE_DIR=$SDL2_PREFIX/include/SDL2 -DSDL2_LIBRARY=$SDL2_PREFIX/lib/libSDL2.dylib"
         fi
         cmake -G "Unix Makefiles" -B ${{github.workspace}}/build $CMAKE_ARGS
 

--- a/.github/workflows/pull-request-action.yml
+++ b/.github/workflows/pull-request-action.yml
@@ -38,7 +38,12 @@ jobs:
       run: |
         brew install curl sdl2
         # Set environment variables for SDL2 on macOS
-        echo "SDL2_DIR=$(brew --prefix sdl2)" >> $GITHUB_ENV
+        SDL2_PREFIX=$(brew --prefix sdl2)
+        echo "SDL2_DIR=$SDL2_PREFIX" >> $GITHUB_ENV
+        echo "SDL2_CFLAGS=-I$SDL2_PREFIX/include" >> $GITHUB_ENV
+        echo "CFLAGS=-I$SDL2_PREFIX/include" >> $GITHUB_ENV
+        echo "CXXFLAGS=-I$SDL2_PREFIX/include" >> $GITHUB_ENV
+        echo "C_INCLUDE_PATH=$SDL2_PREFIX/include:$C_INCLUDE_PATH" >> $GITHUB_ENV
         echo "PKG_CONFIG_PATH=$(brew --prefix sdl2)/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
 
     - name: Debug SDL2 installation (macOS)
@@ -72,8 +77,6 @@ jobs:
           echo "Using SDL2_PREFIX: $SDL2_PREFIX"
           # Set include dir to parent of SDL2 so #include <SDL2/SDL.h> works
           CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_PREFIX_PATH=$SDL2_PREFIX -DSDL2_INCLUDE_DIR=$SDL2_PREFIX/include -DSDL2_LIBRARY=$SDL2_PREFIX/lib/libSDL2.dylib"
-          # Also pass SDL2 flags to C compiler for external projects like LVGL
-          CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_C_FLAGS='-I$SDL2_PREFIX/include'"
         fi
         echo "CMAKE_ARGS: $CMAKE_ARGS"
         cmake -G "Unix Makefiles" -B ${{github.workspace}}/build $CMAKE_ARGS

--- a/.github/workflows/pull-request-action.yml
+++ b/.github/workflows/pull-request-action.yml
@@ -19,17 +19,23 @@ env:
 
 jobs:
   build:
-    # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
-    # You can convert this to a matrix build if you need cross-platform coverage.
-    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-22.04
+    # Build and test on both Ubuntu and macOS using a matrix strategy
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, macos-latest]
     
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install Ubuntu dependencies
+    - name: Install dependencies (Ubuntu)
+      if: runner.os == 'Linux'
       run: sudo apt-get install -y libcurl4-openssl-dev libsdl2-dev clang-tools
+
+    - name: Install dependencies (macOS)
+      if: runner.os == 'macOS'
+      run: brew install curl sdl2
     
     - name: Get cmake version
       run: cmake --version
@@ -37,13 +43,14 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -G "Unix Makefiles" -B ${{github.workspace}}/build -DCMAKE_TOOLCHAIN_FILE=../cmake/host-toolchain.cmake -DENABLE_CLANG_TIDY=ON
+      run: cmake -G "Unix Makefiles" -B ${{github.workspace}}/build -DCMAKE_TOOLCHAIN_FILE=../cmake/host-toolchain.cmake -DENABLE_CLANG_TIDY=${{ runner.os == 'Linux' && 'ON' || 'OFF' }}
 
     - name: Build
       # Build your program with the given configuration
       run: cmake --build ${{github.workspace}}/build
 
     - name: Run clang-tidy static analysis
+      if: runner.os == 'Linux'
       working-directory: ${{github.workspace}}/build
       # clang-tidy is automatically invoked during build via CMAKE_CXX_CLANG_TIDY
       # If any issues are found with --warnings-as-errors, the build will fail

--- a/.github/workflows/pull-request-action.yml
+++ b/.github/workflows/pull-request-action.yml
@@ -22,7 +22,7 @@ jobs:
     # Build and test on both Ubuntu and macOS using a matrix strategy
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-latest]
+        os: [ubuntu-22.04, macos-14]
     
     runs-on: ${{ matrix.os }}
 
@@ -35,7 +35,7 @@ jobs:
 
     - name: Install dependencies (macOS)
       if: runner.os == 'macOS'
-      run: brew install curl sdl2
+      run: brew install curl sdl2 
     
     - name: Get cmake version
       run: cmake --version

--- a/.github/workflows/pull-request-action.yml
+++ b/.github/workflows/pull-request-action.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -G "Unix Makefiles" -B ${{github.workspace}}/build -DCMAKE_TOOLCHAIN_FILE=../cmake/host-toolchain.cmake
+      run: cmake -G "Unix Makefiles" -B ${{github.workspace}}/build -DCMAKE_TOOLCHAIN_FILE=../cmake/host-toolchain.cmake -DENABLE_CLANG_TIDY=ON
 
     - name: Build
       # Build your program with the given configuration

--- a/BUILD_GUIDE.md
+++ b/BUILD_GUIDE.md
@@ -1,0 +1,125 @@
+# Build Guide & Performance Tips
+
+## Quick Start (Fast Development Builds with Code Quality)
+
+```bash
+cd build
+cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/host-toolchain.cmake ..
+cmake --build . -j$(nproc)
+```
+
+**Default behavior:** Clang-tidy is **enabled** for code quality checks. With ccache, builds are still fast.
+
+## Building without Static Analysis (Fastest)
+
+To skip clang-tidy checks for maximum speed:
+
+```bash
+cd build
+cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/host-toolchain.cmake -DENABLE_CLANG_TIDY=OFF ..
+cmake --build . -j$(nproc)
+```
+
+## Building with Static Analysis (Default)
+
+Clang-tidy runs by default with ccache for efficient caching:
+
+## Clean Rebuild
+
+```bash
+rm -rf build
+mkdir build
+cd build
+cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/host-toolchain.cmake ..
+cmake --build .
+```
+
+## Performance Optimization Tips
+
+### 1. ccache (Automatic)
+
+ccache is **auto-detected and enabled** during CMake configuration if installed:
+
+```bash
+# Install ccache (if not already installed):
+# Ubuntu/Debian
+sudo apt-get install ccache
+
+# macOS
+brew install ccache
+```
+
+Once installed, just run `cmake ..` and it will be automatically enabled. Subsequent builds will be dramatically faster (~10x).
+
+### 2. Parallel Build Jobs
+
+Build with multiple cores:
+```bash
+cmake --build . -j$(nproc)  # Uses all available cores
+cmake --build . -j8          # Or specify explicitly
+```
+
+### 3. Run Tests
+
+```bash
+ctest --output-on-failure -j$(nproc)
+```
+
+## Recommended Workflow
+
+### Standard Development (with code quality):
+```bash
+cd build
+cmake --build . -j$(nproc)  # Clang-tidy enabled by default
+```
+
+### Maximum Speed (skip linting temporarily):
+```bash
+cd build
+cmake -DENABLE_CLANG_TIDY=OFF ..
+cmake --build . -j$(nproc)  # No linting, fastest possible
+```
+
+### CI/CD:
+Clang-tidy is enabled by default in GitHub Actions for all builds.
+
+## Options
+
+### Disable clang-tidy:
+```bash
+cmake -DENABLE_CLANG_TIDY=OFF ..
+```
+
+### Legacy skip option:
+```bash
+cmake -DSKIP_CLANG_TIDY=ON ..
+```
+
+## Troubleshooting
+
+**"clang-tidy not found"**
+```bash
+# Install clang-tools
+sudo apt-get install clang-tools
+```
+
+**Build cache issues**
+```bash
+# Clear CMake cache
+rm -rf build/CMakeCache.txt build/CMakeFiles
+cmake ..
+```
+
+**Out of memory during build**
+- Reduce parallel jobs: `cmake --build . -j4`
+- Enable swap if available
+
+## Build Time Reference (with ccache)
+
+| Configuration | Time (Estimated) |
+|---|---|
+| Full clean build (with clang-tidy, ccache empty) | 8-12 min |
+| Full clean build (no clang-tidy, ccache empty) | 2-3 min |
+| Incremental build (with clang-tidy, ccache hit) | 5-15 sec |
+| Incremental build (no clang-tidy, ccache hit) | 2-5 sec |
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,22 @@ include(FetchContent)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Enable clang-tidy for host builds only
+if(IS_HOST_BUILD AND NOT SKIP_CLANG_TIDY)
+    find_program(CLANG_TIDY_EXE clang-tidy)
+    if(CLANG_TIDY_EXE)
+        message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
+        set(CMAKE_CXX_CLANG_TIDY 
+            "${CLANG_TIDY_EXE}"
+            "--header-filter=.*src/.*"
+            "-checks=-*,readability-*,performance-*,clang-analyzer-*,modernize-use-auto,modernize-use-bool-literals,modernize-loop-convert,modernize-make-unique,modernize-make-shared,modernize-use-noexcept,modernize-use-override,modernize-use-nullptr,-readability-function-cognitive-complexity,-readability-magic-numbers,-readability-identifier-length,-modernize-use-trailing-return-type,-clang-analyzer-security.insecureAPI.strcpy,-google-*"
+            "--warnings-as-errors=*"
+        )
+    else()
+        message(WARNING "clang-tidy not found. Static analysis will be skipped.")
+    endif()
+endif()
+
 add_subdirectory("lvgl")
 add_subdirectory("src")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ if(IS_HOST_BUILD AND NOT SKIP_CLANG_TIDY)
             "${CLANG_TIDY_EXE}"
             "-checks=-*,readability-*,performance-*,clang-analyzer-*,modernize-use-auto,modernize-use-bool-literals,modernize-loop-convert,modernize-make-unique,modernize-make-shared,modernize-use-noexcept,modernize-use-override,modernize-use-nullptr,-readability-function-cognitive-complexity,-readability-magic-numbers,-readability-identifier-length,-modernize-use-trailing-return-type,-clang-analyzer-security.insecureAPI.strcpy,-google-*"
             "--warnings-as-errors=*"
+            #"--header-filter: '^(?!.*/build.*/lvgl|.*/json11).*(.*\.(hpp?|cpp))$'"
         )
     else()
         message(WARNING "clang-tidy not found. Static analysis will be skipped.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,15 +15,26 @@ include(FetchContent)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Auto-detect and use ccache if available for faster rebuilds
+find_program(CCACHE_FOUND ccache)
+if(CCACHE_FOUND)
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
+    message(STATUS "ccache found and enabled for faster rebuilds")
+endif()
+
+# Clang-tidy configuration
+# Enabled by default for code quality, can be disabled with -DENABLE_CLANG_TIDY=OFF
+option(ENABLE_CLANG_TIDY "Enable clang-tidy static analysis during compilation" ON)
 
 add_subdirectory("lvgl")
 add_subdirectory("src")
 
-# Enable clang-tidy for host builds only
-if(IS_HOST_BUILD AND NOT SKIP_CLANG_TIDY)
+# Enable clang-tidy for host builds only (if explicitly enabled or SKIP_CLANG_TIDY not set)
+if(IS_HOST_BUILD AND (ENABLE_CLANG_TIDY OR NOT SKIP_CLANG_TIDY))
     find_program(CLANG_TIDY_EXE clang-tidy)
     if(CLANG_TIDY_EXE)
-        message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
+        message(STATUS "clang-tidy enabled: ${CLANG_TIDY_EXE}")
         set(CMAKE_CXX_CLANG_TIDY 
             "${CLANG_TIDY_EXE}"
             "-checks=-*,readability-*,performance-*,clang-analyzer-*,modernize-use-auto,modernize-use-bool-literals,modernize-loop-convert,modernize-make-unique,modernize-make-shared,modernize-use-noexcept,modernize-use-override,modernize-use-nullptr,-readability-function-cognitive-complexity,-readability-magic-numbers,-readability-identifier-length,-modernize-use-trailing-return-type,-clang-analyzer-security.insecureAPI.strcpy,-google-*"
@@ -31,6 +42,10 @@ if(IS_HOST_BUILD AND NOT SKIP_CLANG_TIDY)
         )
     else()
         message(WARNING "clang-tidy not found. Static analysis will be skipped.")
+    endif()
+else()
+    if(IS_HOST_BUILD AND NOT ENABLE_CLANG_TIDY)
+        message(STATUS "clang-tidy disabled. Re-enable with: cmake -DENABLE_CLANG_TIDY=ON")
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ FetchContent_Declare(
     json11
     GIT_REPOSITORY https://github.com/dropbox/json11.git
     GIT_TAG master
+    PATCH_COMMAND ${CMAKE_COMMAND} -E sed -i "s/cmake_minimum_required(VERSION 2.8)/cmake_minimum_required(VERSION 3.5)/" CMakeLists.txt
 )
 FetchContent_MakeAvailable(json11)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ FetchContent_Declare(
     json11
     GIT_REPOSITORY https://github.com/dropbox/json11.git
     GIT_TAG master
-#    PATCH_COMMAND ${CMAKE_COMMAND} -E sed -i "s/cmake_minimum_required(VERSION 2.8)/cmake_minimum_required(VERSION 3.5)/" CMakeLists.txt
+    PATCH_COMMAND patch -p0 < ${CMAKE_SOURCE_DIR}/cmake/json11.patch
 )
 FetchContent_MakeAvailable(json11)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ FetchContent_Declare(
     json11
     GIT_REPOSITORY https://github.com/dropbox/json11.git
     GIT_TAG master
-    PATCH_COMMAND ${CMAKE_COMMAND} -E sed -i "s/cmake_minimum_required(VERSION 2.8)/cmake_minimum_required(VERSION 3.5)/" CMakeLists.txt
+#    PATCH_COMMAND ${CMAKE_COMMAND} -E sed -i "s/cmake_minimum_required(VERSION 2.8)/cmake_minimum_required(VERSION 3.5)/" CMakeLists.txt
 )
 FetchContent_MakeAvailable(json11)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,6 @@ if(IS_HOST_BUILD AND NOT SKIP_CLANG_TIDY)
             "${CLANG_TIDY_EXE}"
             "-checks=-*,readability-*,performance-*,clang-analyzer-*,modernize-use-auto,modernize-use-bool-literals,modernize-loop-convert,modernize-make-unique,modernize-make-shared,modernize-use-noexcept,modernize-use-override,modernize-use-nullptr,-readability-function-cognitive-complexity,-readability-magic-numbers,-readability-identifier-length,-modernize-use-trailing-return-type,-clang-analyzer-security.insecureAPI.strcpy,-google-*"
             "--warnings-as-errors=*"
-            #"--header-filter: '^(?!.*/build.*/lvgl|.*/json11).*(.*\.(hpp?|cpp))$'"
         )
     else()
         message(WARNING "clang-tidy not found. Static analysis will be skipped.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,10 @@ include(FetchContent)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+
+add_subdirectory("lvgl")
+add_subdirectory("src")
+
 # Enable clang-tidy for host builds only
 if(IS_HOST_BUILD AND NOT SKIP_CLANG_TIDY)
     find_program(CLANG_TIDY_EXE clang-tidy)
@@ -22,7 +26,6 @@ if(IS_HOST_BUILD AND NOT SKIP_CLANG_TIDY)
         message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
         set(CMAKE_CXX_CLANG_TIDY 
             "${CLANG_TIDY_EXE}"
-            "--header-filter=.*src/.*"
             "-checks=-*,readability-*,performance-*,clang-analyzer-*,modernize-use-auto,modernize-use-bool-literals,modernize-loop-convert,modernize-make-unique,modernize-make-shared,modernize-use-noexcept,modernize-use-override,modernize-use-nullptr,-readability-function-cognitive-complexity,-readability-magic-numbers,-readability-identifier-length,-modernize-use-trailing-return-type,-clang-analyzer-security.insecureAPI.strcpy,-google-*"
             "--warnings-as-errors=*"
         )
@@ -30,9 +33,6 @@ if(IS_HOST_BUILD AND NOT SKIP_CLANG_TIDY)
         message(WARNING "clang-tidy not found. Static analysis will be skipped.")
     endif()
 endif()
-
-add_subdirectory("lvgl")
-add_subdirectory("src")
 
 if(IS_HOST_BUILD)
 add_subdirectory("tests")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,16 @@ if(CCACHE_FOUND)
     message(STATUS "ccache found and enabled for faster rebuilds")
 endif()
 
+# =====================================================
+# Fetch json11 from public repository
+# =====================================================
+FetchContent_Declare(
+    json11
+    GIT_REPOSITORY https://github.com/dropbox/json11.git
+    GIT_TAG master
+)
+FetchContent_MakeAvailable(json11)
+
 # Clang-tidy configuration
 # Enabled by default for code quality, can be disabled with -DENABLE_CLANG_TIDY=OFF
 option(ENABLE_CLANG_TIDY "Enable clang-tidy static analysis during compilation" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ FetchContent_Declare(
     json11
     GIT_REPOSITORY https://github.com/dropbox/json11.git
     GIT_TAG master
-    PATCH_COMMAND patch -p0 < ${CMAKE_SOURCE_DIR}/cmake/json11.patch
+    PATCH_COMMAND patch -N -r - -p0 < ${CMAKE_SOURCE_DIR}/cmake/json11.patch || true
 )
 FetchContent_MakeAvailable(json11)
 

--- a/build_arm.sh
+++ b/build_arm.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 mkdir -p ./build_arm
 cmake -B ./build_arm -DCMAKE_TOOLCHAIN_FILE=../cmake/arm-toolchain.cmake
-cmake --build ./build_arm/
+cmake --build ./build_arm/ -j$(nproc)

--- a/cmake/json11.patch
+++ b/cmake/json11.patch
@@ -1,0 +1,5 @@
+--- CMakeLists.txt.orig
++++ CMakeLists.txt
+@@ -1 +1 @@
+-cmake_minimum_required(VERSION 2.8)
++cmake_minimum_required(VERSION 3.5)

--- a/install_deps.sh
+++ b/install_deps.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 sudo dpkg --add-architecture i386
 sudo apt update
-sudo apt install libc6:i386 libstdc++6:i386 zlib1g:i386
+sudo apt install -y libc6:i386 libstdc++6:i386 zlib1g:i386
+sudo apt install -y ccache

--- a/lvgl/CMakeLists.txt
+++ b/lvgl/CMakeLists.txt
@@ -2,7 +2,8 @@ cmake_minimum_required(VERSION 3.16)
 
 set(LVGL_VERSION "v9.4.0")
 
-set(LV_CONF_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../lv_conf.h")
+# Use absolute path for lv_conf.h so it works with ExternalProject
+set(LV_CONF_PATH "${CMAKE_SOURCE_DIR}/lv_conf.h")
 
 include(ExternalProject)
 

--- a/src/Backplate/BackplateComms.cpp
+++ b/src/Backplate/BackplateComms.cpp
@@ -362,7 +362,7 @@ void BackplateComms::TaskBodyComms ()
                     lux = (resp.GetPayload()[1] << 8) | resp.GetPayload()[0];
                 }
 
-                //LOG_INFO_STREAM("BackplateComms: Ambient Light Sensor Value = " << lux);
+                LOG_DEBUG_STREAM("BackplateComms: Ambient Light Sensor Value = " << lux);
                 break;
             }
 

--- a/src/Backplate/BackplateComms.cpp
+++ b/src/Backplate/BackplateComms.cpp
@@ -220,7 +220,7 @@ bool BackplateComms::IsTimeout(timeval &startTime, int timeoutUs)
 {
     timeval currentTime;
     DateTimeProvider->gettimeofday(currentTime);
-    long elapsedUs = (currentTime.tv_sec - startTime.tv_sec) * 1000000 +
+    long elapsedUs = ((currentTime.tv_sec - startTime.tv_sec) * 1000000) +
                      (currentTime.tv_usec - startTime.tv_usec);
 
     
@@ -285,7 +285,7 @@ bool BackplateComms::GetInfo(MessageType command, MessageType expectedResponse)
             if (responseMsg.GetMessageCommand() == expectedResponse)
             {
                 std::cout << "GetInfo: Received expected response for command "
-                          << static_cast<uint16_t>(command) << std::endl;
+                          << static_cast<uint16_t>(command) << '\n';
                 return true;
             }
         }

--- a/src/Backplate/MessageParser.cpp
+++ b/src/Backplate/MessageParser.cpp
@@ -70,13 +70,10 @@ std::vector<ResponseMessage> MessageParser::Feed(const uint8_t* data, size_t len
             parsed.push_back(msg);
             // Erase the consumed bytes
             buffer_.erase(buffer_.begin(), buffer_.begin() + totalMsgLen);
-            // Continue to parse next messages
-            continue;
         } else {
             // Parsing failed (likely CRC or malformed). Reset parser to initial
             // behaviour by discarding the first byte and continue searching
             buffer_.erase(buffer_.begin());
-            continue;
         }
     }
 

--- a/src/Backplate/MessageParser.cpp
+++ b/src/Backplate/MessageParser.cpp
@@ -36,7 +36,6 @@ std::vector<ResponseMessage> MessageParser::Feed(const uint8_t* data, size_t len
             buffer_.erase(buffer_.begin(), buffer_.begin() + idx);
             // reset iterator to start
             it = buffer_.begin();
-            idx = 0;
         }
 
         // Need minimum bytes for header: preamble(4) + cmd(2) + len(2) + crc(2)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,12 +8,11 @@ include(FetchContent)
 # (removed spdlog FetchContent — using in-tree lightweight logger)
 
 # =====================================================
-# 2. Create json11 library without clang-tidy
+# 2. json11 library (fetched from external repository)
 # =====================================================
-add_library(json11 STATIC ../third-party/json11/json11.cpp)
-target_include_directories(json11 PUBLIC ${CMAKE_SOURCE_DIR}/third-party/json11)
-# Disable clang-tidy for json11 library
-set_target_properties(json11 PROPERTIES CXX_CLANG_TIDY "")
+# json11 is now fetched from GitHub by FetchContent in main CMakeLists.txt
+# The json11 target is automatically created by the external project
+message(STATUS "json11 external project available at: ${json11_SOURCE_DIR}")
 
 # =====================================================
 # 3. Define your actual build target
@@ -67,7 +66,12 @@ else()
     message(FATAL_ERROR "Could not find libcurl headers in ${CURL_INCLUDE_DIR}")
 endif()
 
+# Add LVGL include directories - need both the main include and parent for lv_conf.h relative path
 target_include_directories(cuckoo PRIVATE ${CMAKE_BINARY_DIR}/lvgl/src)
+target_include_directories(cuckoo PRIVATE ${CMAKE_SOURCE_DIR})
+
+# Add LV_CONF_PATH definition to match LVGL library build
+target_compile_definitions(cuckoo PRIVATE LV_CONF_PATH="${CMAKE_SOURCE_DIR}/lv_conf.h")
 
 # Add project include directory (in-tree lightweight logger)
 target_include_directories(cuckoo PRIVATE ${CMAKE_SOURCE_DIR}/include)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -101,6 +101,7 @@ set_target_properties(cuckoo PROPERTIES
 )
 endif()
 
+
 # =====================================================
 # Copy emulation config for host builds
 # =====================================================

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,14 @@ include(FetchContent)
 # (removed spdlog FetchContent — using in-tree lightweight logger)
 
 # =====================================================
+# 2. Create json11 library without clang-tidy
+# =====================================================
+add_library(json11 STATIC ../third-party/json11/json11.cpp)
+target_include_directories(json11 PUBLIC ${CMAKE_SOURCE_DIR}/third-party/json11)
+# Disable clang-tidy for json11 library
+set_target_properties(json11 PROPERTIES CXX_CLANG_TIDY "")
+
+# =====================================================
 # 3. Define your actual build target
 # =====================================================
 set (
@@ -15,7 +23,6 @@ set (
     main.cpp
     ScreenManager.cpp
     ConfigurationReader.cpp
-    ../third-party/json11/json11.cpp
     HAL/Beeper.cpp
     HAL/Display.cpp
     HAL/BitmapFont.cpp
@@ -60,8 +67,6 @@ else()
     message(FATAL_ERROR "Could not find libcurl headers in ${CURL_INCLUDE_DIR}")
 endif()
 
-# Add json11 include directory
-target_include_directories(cuckoo PRIVATE ${CMAKE_SOURCE_DIR}/third-party/json11)
 target_include_directories(cuckoo PRIVATE ${CMAKE_BINARY_DIR}/lvgl/src)
 
 # Add project include directory (in-tree lightweight logger)
@@ -75,6 +80,7 @@ target_link_directories(cuckoo PRIVATE ${CMAKE_BINARY_DIR}/lvgl/src/lvgl-build/l
 # We use dlopen/dlsym to load it at runtime on the target device
 target_link_libraries(
     cuckoo PRIVATE 
+    json11
     liblvgl.a 
     pthread 
     dl

--- a/src/ConfigurationReader.cpp
+++ b/src/ConfigurationReader.cpp
@@ -150,7 +150,7 @@ std::vector<std::string> ConfigurationReader::get_keys() const
     return keys;
 }
 
-std::string ConfigurationReader::get_executable_directory() const
+std::string ConfigurationReader::get_executable_directory()
 {
     char path[PATH_MAX];
     ssize_t count = readlink("/proc/self/exe", path, PATH_MAX);
@@ -241,7 +241,7 @@ bool ConfigurationReader::has_home_assistant_config() const
     return false;
 }
 
-std::string ConfigurationReader::read_file_content(const std::string& filepath) const
+std::string ConfigurationReader::read_file_content(const std::string& filepath)
 {
     std::ifstream file(filepath);
     if (!file.is_open()) {

--- a/src/ConfigurationReader.hpp
+++ b/src/ConfigurationReader.hpp
@@ -141,7 +141,7 @@ private:
      * 
      * @return std::string The executable directory path
      */
-    std::string get_executable_directory() const;
+    static std::string get_executable_directory();
 
     /**
      * @brief Read the entire file content into a string
@@ -149,7 +149,7 @@ private:
      * @param filepath The path to the file to read
      * @return std::string The file content, empty string on error
      */
-    std::string read_file_content(const std::string& filepath) const;
+    static std::string read_file_content(const std::string& filepath);
 };
 
 #endif // CONFIGURATION_READER_HPP

--- a/src/HAL/Inputs.cpp
+++ b/src/HAL/Inputs.cpp
@@ -3,9 +3,10 @@
 #include <fcntl.h>
 #include <cstring>
 #include <stdio.h>
+#include <utility>
 
 Inputs::Inputs(std::string button_path, std::string rotary_path) : 
-    button_path_(button_path), rotary_path_(rotary_path), button_fd_(-1), rotary_fd_(-1), should_stop_(false)
+    button_path_(std::move(button_path)), rotary_path_(std::move(rotary_path)), button_fd_(-1), rotary_fd_(-1), should_stop_(false)
 {
 }
 

--- a/src/HAL/Inputs.cpp
+++ b/src/HAL/Inputs.cpp
@@ -62,7 +62,7 @@ void Inputs::polling_loop()
 {
     while (!should_stop_) 
     {
-        bool button_event = poll_device(InputDeviceType::BUTTON, button_fd_);
+        poll_device(InputDeviceType::BUTTON, button_fd_);
         bool rotary_event = poll_device(InputDeviceType::ROTARY, rotary_fd_);
 
         if (rotary_event) {

--- a/src/Integrations/CurlWrapperJson.cpp
+++ b/src/Integrations/CurlWrapperJson.cpp
@@ -31,7 +31,9 @@ static std::vector<std::string> splitLlines(const std::string& input)
     std::stringstream ss(input);
     std::string line;
     while (std::getline(ss, line))
+    {
         lines.push_back(rtrim(line));
+    }
     return lines;
 }
 
@@ -39,16 +41,26 @@ static std::vector<std::string> splitLlines(const std::string& input)
 bool CurlWrapperJson::Startup()
 {
     if(!curlInitialized_)
+    {
         curlInitialized_ = curlWrapper_.initialize();
+    }
+
     if(curlInitialized_)
     {
         if(curl_ == nullptr)
+        {
             curl_ = curlWrapper_.easy_init();
+        }
         if(curl_ == nullptr)
+        {
             LOG_ERROR_STREAM("Failed to initialize curlWrapper_");
+        }
     }
     else
+    {
         LOG_ERROR_STREAM("Failed to initialize libcurl");
+    }
+
     return curlInitialized_ && curl_ != nullptr;
 }
 
@@ -74,7 +86,9 @@ json11::Json CurlWrapperJson::jsonGetOrPost(std::string url, std::string const &
         struct curl_slist *headers = nullptr;
 
         if(headerAuthBearer_ != "")
+        {
             headers = curlWrapper_.slist_append(headers, headerAuthBearer_.c_str());
+        }
         headers = curlWrapper_.slist_append(headers, "Content-Type: application/json");
 
         LOG_INFO_STREAM("CurlWrapperJson: URL: " << url);
@@ -84,7 +98,7 @@ json11::Json CurlWrapperJson::jsonGetOrPost(std::string url, std::string const &
         curlWrapper_.easy_setopt(curl_, CURLOPT_WRITEDATA, &responseBody);
         curlWrapper_.easy_setopt(curl_, CURLOPT_HEADERFUNCTION, callbackString);
         curlWrapper_.easy_setopt(curl_, CURLOPT_HEADERDATA, &responseHeaders);
-        if(postData != "")
+        if(postData.empty() == false)
         {
             // LOG_INFO_STREAM("CurlWrapperJson request post: " << postData);
             curlWrapper_.easy_setopt(curl_, CURLOPT_POSTFIELDS, postData.c_str());
@@ -110,17 +124,24 @@ json11::Json CurlWrapperJson::jsonGetOrPost(std::string url, std::string const &
                 std::string parse_error;
                 js = json11::Json::parse(responseBody, parse_error);
                 if (!parse_error.empty())
+                {
                     LOG_ERROR_STREAM("CurlWrapperJson request JSON parse error: " << parse_error);
+                }
             }
             else
+            {
                 LOG_INFO_STREAM("CurlWrapperJson request completed body is not JSON = " << responseBody);
-
+            }
         }
         else
+        {
             LOG_ERROR_STREAM("CurlWrapperJson request failed: " << curlWrapper_.easy_strerror(res));
+        }
 
         if(headers)
+        {
             curlWrapper_.slist_free_all(headers);
+        }
     }
 
     Shutdown();

--- a/src/Integrations/CurlWrapperJson.cpp
+++ b/src/Integrations/CurlWrapperJson.cpp
@@ -66,7 +66,7 @@ bool CurlWrapperJson::Startup()
 
 void CurlWrapperJson::Shutdown()
 {
-    if(curl_)
+    if(curl_ != nullptr)
     {
         curlWrapper_.easy_cleanup(curl_);
         curl_ = nullptr;
@@ -79,13 +79,13 @@ json11::Json CurlWrapperJson::jsonGetOrPost(std::string url, std::string const &
 
     Startup();
 
-    if(curl_)
+    if(curl_ != nullptr)
     {
         std::string responseBody;
         std::string responseHeaders;
         struct curl_slist *headers = nullptr;
 
-        if(headerAuthBearer_ != "")
+        if(!headerAuthBearer_.empty())
         {
             headers = curlWrapper_.slist_append(headers, headerAuthBearer_.c_str());
         }
@@ -98,7 +98,8 @@ json11::Json CurlWrapperJson::jsonGetOrPost(std::string url, std::string const &
         curlWrapper_.easy_setopt(curl_, CURLOPT_WRITEDATA, &responseBody);
         curlWrapper_.easy_setopt(curl_, CURLOPT_HEADERFUNCTION, callbackString);
         curlWrapper_.easy_setopt(curl_, CURLOPT_HEADERDATA, &responseHeaders);
-        if(postData.empty() == false)
+        
+        if(!postData.empty())
         {
             // LOG_INFO_STREAM("CurlWrapperJson request post: " << postData);
             curlWrapper_.easy_setopt(curl_, CURLOPT_POSTFIELDS, postData.c_str());
@@ -138,7 +139,7 @@ json11::Json CurlWrapperJson::jsonGetOrPost(std::string url, std::string const &
             LOG_ERROR_STREAM("CurlWrapperJson request failed: " << curlWrapper_.easy_strerror(res));
         }
 
-        if(headers)
+        if(headers != nullptr)
         {
             curlWrapper_.slist_free_all(headers);
         }

--- a/src/Integrations/CurlWrapperJson.cpp
+++ b/src/Integrations/CurlWrapperJson.cpp
@@ -19,7 +19,7 @@ static std::size_t callbackString( const char* in, std::size_t size, std::size_t
 static std::string &rtrim(std::string &s)
 {
     s.erase(
-        std::find_if( s.rbegin(), s.rend(), std::not1(std::ptr_fun<int, int>(std::isspace)) ).base()
+        std::find_if( s.rbegin(), s.rend(), [](int ch) { return std::isspace(ch) == 0; } ).base()
         , s.end()
         );
     return s;

--- a/src/Integrations/IntegrationContainer.cpp
+++ b/src/Integrations/IntegrationContainer.cpp
@@ -44,7 +44,9 @@ void IntegrationContainer::LoadIntegrationsFromConfig(const std::string& configP
     for (const auto& integration : parsed_json["integrations"].array_items()) 
     {
         if (!integration.is_object())
+        {
             continue; // skip invalid entries
+        }
 
         std::string name = integration["name"].string_value();
         std::string type = integration["type"].string_value();
@@ -53,8 +55,10 @@ void IntegrationContainer::LoadIntegrationsFromConfig(const std::string& configP
             ? std::to_string(integration["id"].int_value())
             : integration["id"].string_value()
         );
-        if(id == "")
+        if(id.empty())
+        {
             id = name;
+        }
 
         if (type == "HomeAssistant") 
         {
@@ -82,11 +86,13 @@ void IntegrationContainer::LoadIntegrationsFromConfig(const std::string& configP
     }
 }
 
-std::string IntegrationContainer::ReadFileContents(const std::string& filepath) const
+std::string IntegrationContainer::ReadFileContents(const std::string& filepath)
 {
     std::ifstream file(filepath);
     if (!file.is_open())
+    {
         return "";
+    }
     
     std::stringstream buffer;
     buffer << file.rdbuf();
@@ -98,7 +104,9 @@ IntegrationSwitchBase* IntegrationContainer::GetSwitchById(std::string const  &i
 {
     auto it = switchMap_.find(id);
     if (it != switchMap_.end())
+    {
         return it->second.get();
+    }
 
     return nullptr;
 }
@@ -107,7 +115,9 @@ IntegrationDimmerBase* IntegrationContainer::GetDimmerById(std::string const  &i
 {
     auto it = dimmerMap_.find(id);
     if (it != dimmerMap_.end())
+    {
         return it->second.get();
+    }
 
     return nullptr;
 }

--- a/src/Integrations/IntegrationContainer.hpp
+++ b/src/Integrations/IntegrationContainer.hpp
@@ -20,7 +20,7 @@ class IntegrationContainer
         IntegrationDimmerBase* GetDimmerById(std::string const  &id);
         
     private:
-        std::string ReadFileContents(const std::string &filepath) const;
+        static std::string ReadFileContents(const std::string &filepath);
         
         std::map<std::string, std::unique_ptr<IntegrationSwitchBase>> switchMap_;
         std::map<std::string, std::unique_ptr<IntegrationDimmerBase>> dimmerMap_;

--- a/src/ScreenManager.cpp
+++ b/src/ScreenManager.cpp
@@ -246,7 +246,7 @@ void ScreenManager::BuildMenuScreenFromJSON(const json11::Json &screenJson)
 
     // if there is a "nextScreen", add a "Previous"
     std::string screenNext = screen->GetNextScreenId();
-    if(screenNext.empty())
+    if(!screenNext.empty())
     {
         screen->AddMenuItem(MenuItem("Previous", "", menuIcons["left"], true));
     }

--- a/src/ScreenManager.cpp
+++ b/src/ScreenManager.cpp
@@ -18,22 +18,29 @@ void ScreenManager::GoToScreenPtr(ScreenBase *screen)
 {
     if(screen != nullptr)
     {
-        if(current_screen_)
+        if(current_screen_ != nullptr)
+        {
             current_screen_->OnChangeFocus(false);
+        }
+
         current_screen_ = screen;
         screen_history_.push(current_screen_);
         current_screen_->OnChangeFocus(true);
         LOG_INFO_STREAM("ScreenManager: Navigated to screen ID \"" << current_screen_->GetId() << "\" / \"" << current_screen_->GetName() << "\"");
     }
     else
+    {
         LOG_ERROR_STREAM("ScreenManager::GoToScreenPtr NULL screen ptr");
+    }
 }
 
 void ScreenManager::GoToFirstScreen(std::string id)
 {
-    if(id == "")
+    if(id.empty())
+    {
         id = firstScreenId_;
-    ScreenBase* screen = (id != "" ? GetScreenById(id) : nullptr);
+    }
+    ScreenBase* screen = (id.empty() ? nullptr : GetScreenById(id));
     if(screen == nullptr)
     {
         LOG_INFO_STREAM("ScreenManager::GoToFirstScreen Unable to find screen ID \"" << id << "\"");
@@ -41,15 +48,22 @@ void ScreenManager::GoToFirstScreen(std::string id)
         {
             screen = GetScreenById("1");
             if(screen == nullptr)
+            {
                 LOG_INFO_STREAM("ScreenManager::GoToFirstScreen Unable to find screen ID \"1\"");
+            }
         }
     }
     // no screen found, try to find a HomeScreen class instance
     if(screen == nullptr)
     {
         for(auto &pair: screens_)
-            if((screen = dynamic_cast<HomeScreen *>(pair.second.get())))
+        {
+            screen = dynamic_cast<HomeScreen *>(pair.second.get());
+            if(screen != nullptr)
+            {
                 break;
+            }
+        }
 
         // no HomeScreen class instance found, build one
         if(screen == nullptr)
@@ -62,29 +76,39 @@ void ScreenManager::GoToFirstScreen(std::string id)
     }
 
     if (screen == nullptr)
+    {
         LOG_ERROR_STREAM("ScreenManager::GoToFirstScreen Unable to find a home screen.");
+    }
     else
+    {
         GoToScreenPtr(screen);
+    }
 }
 
 void ScreenManager::GoToNextScreen(std::string const & id)
 {
-    ScreenBase* screen = (id != "" ? GetScreenById(id) : nullptr);
+    ScreenBase* screen = (id.empty() ? nullptr : GetScreenById(id));
     if (screen == nullptr)
+    {
         LOG_ERROR_STREAM("ScreenManager: Unable to find screen \"" << id << "\"");
+    }
     else
+    {
         GoToScreenPtr(screen);
+    }
 }
 
 void ScreenManager::GoToPreviousScreen()
 {
     if(screen_history_.size() > 1)
     {
-        if(current_screen_)
+        if(current_screen_ != nullptr)
+        {
             current_screen_->OnChangeFocus(false);
+        }
         screen_history_.pop();
         current_screen_ = screen_history_.top();
-        if(current_screen_)
+        if(current_screen_ != nullptr)
         {
             current_screen_->OnChangeFocus(true);
             LOG_INFO_STREAM("ScreenManager: Navigated to screen ID \"" << current_screen_->GetId() << "\" / \"" << current_screen_->GetName() << "\"");
@@ -95,15 +119,19 @@ void ScreenManager::GoToPreviousScreen()
 void ScreenManager::ProcessInputEvent(const InputDeviceType device_type, const struct input_event &event)
 {
     if (current_screen_ != nullptr)
+    {
         current_screen_->handle_input_event(device_type, event);
+    }
 }
 
 void ScreenManager::LoadScreensFromConfig(const std::string& config_path)
 {
     auto configContent = ReadFileContents(config_path);
     if (configContent.empty())
+    {
         // Handle error: could not read config file
         return;
+    }
 
     std::string parse_error;
     json11::Json parsed_json = json11::Json::parse(configContent, parse_error, json11::JsonParse::COMMENTS);
@@ -142,29 +170,43 @@ void ScreenManager::LoadScreensFromConfig(const std::string& config_path)
         transform(type.begin(), type.end(), type.begin(), ::tolower);
 
         if (type == "home") 
+        {
             AddScreen(std::unique_ptr<ScreenBase>(new HomeScreen(this, screen)));
+        }
         else if (type == "menu") 
+        {
             BuildMenuScreenFromJSON(screen);
+        }
         else if (type == "switch") 
+        {
             AddScreen(std::unique_ptr<ScreenBase>(new SwitchScreen(this, screen)));
+        }
         else if (type == "dimmer") 
+        {
             AddScreen(std::unique_ptr<ScreenBase>(new DimmerScreen(this, screen)));
+        }
         else if (type == "analogclock") 
+        {
             AddScreen(std::unique_ptr<ScreenBase>(new AnalogClockScreen(this, screen)));
+        }
         else 
+        {
             LOG_ERROR_STREAM(
                 "ScreenManager: Unknown screen type '" << type
                 << "' for screen \"" << id << "\" / " << "\"" << name << "\""
             );
+        }
     }
 }
 
-std::string ScreenManager::ReadFileContents(const std::string& filepath) const
+std::string ScreenManager::ReadFileContents(const std::string& filepath)
 {
     std::ifstream file(filepath);
     if (!file.is_open())
+    {
         return "";
-    
+    }
+
     std::stringstream buffer;
     buffer << file.rdbuf();
 
@@ -191,7 +233,6 @@ void ScreenManager::BuildMenuScreenFromJSON(const json11::Json &screenJson)
         {"light", MenuIcon::LIGHT},
         {"fan", MenuIcon::FAN},
         {"temperature", MenuIcon::TEMPERATURE},
-        // {"", MenuIcon::},
         {"stop", MenuIcon::STOP},
         {"left", MenuIcon::LEFT},
         {"right", MenuIcon::RIGHT},
@@ -201,12 +242,14 @@ void ScreenManager::BuildMenuScreenFromJSON(const json11::Json &screenJson)
         {"down", MenuIcon::DOWN},
     };
 
-    auto screen = new MenuScreen(this, screenJson);
+    auto *screen = new MenuScreen(this, screenJson);
 
     // if there is a "nextScreen", add a "Previous"
     std::string screenNext = screen->GetNextScreenId();
-    if(screenNext != "")
+    if(screenNext.empty())
+    {
         screen->AddMenuItem(MenuItem("Previous", "", menuIcons["left"], true));
+    }
 
     // add menu entries as configured
     for (const auto& itemJson : screenJson["menuItems"].array_items()) 
@@ -234,9 +277,9 @@ void ScreenManager::BuildMenuScreenFromJSON(const json11::Json &screenJson)
     }
 
     // configure a "Next" or "Back" final menu item
-    MenuIcon menuLastIcon = (screenNext == "" ? menuIcons["close"] : menuIcons["right"]);
-    std::string menuLastName= (screenNext == "" ? "Back" : "Next");
-    bool isPrevious = (screenNext == "");
+    MenuIcon menuLastIcon = (screenNext.empty() ? menuIcons["close"] : menuIcons["right"]);
+    std::string menuLastName= (screenNext.empty() ? "Back" : "Next");
+    bool isPrevious = (screenNext.empty());
     screen->AddMenuItem(MenuItem(menuLastName, screenNext, menuLastIcon, isPrevious));
 
     // in conclusion

--- a/src/ScreenManager.cpp
+++ b/src/ScreenManager.cpp
@@ -150,16 +150,18 @@ void ScreenManager::LoadScreensFromConfig(const std::string& config_path)
 
     if(!parsed_json["firstScreen"].is_null())
     {
-        firstScreenId_ = (
-            parsed_json["firstScreen"].is_number()
-            ? std::to_string(parsed_json["firstScreen"].int_value())
-            : 
-                (
-                    parsed_json["firstScreen"].is_string()
-                    ? parsed_json["firstScreen"].string_value()
-                    : ""
-                )
-            );
+        if (parsed_json["firstScreen"].is_number())
+        {
+            firstScreenId_ = std::to_string(parsed_json["firstScreen"].int_value());
+        }
+        else if (parsed_json["firstScreen"].is_string())
+        {
+            firstScreenId_ = parsed_json["firstScreen"].string_value();
+        }
+        else
+        {
+            firstScreenId_.clear();
+        }
     }
 
     for (const auto& screen : parsed_json["screens"].array_items())
@@ -258,16 +260,19 @@ void ScreenManager::BuildMenuScreenFromJSON(const json11::Json &screenJson)
         transform(itemIconStr.begin(), itemIconStr.end(), itemIconStr.begin(), ::tolower);
         auto menuIconsIt = menuIcons.find(itemIconStr);
 
-        std::string nextScreen = (
-            itemJson["nextScreen"].is_number()
-            ? std::to_string(itemJson["nextScreen"].int_value())
-            : 
-                (
-                    itemJson["nextScreen"].is_string()
-                    ? itemJson["nextScreen"].string_value()
-                    : ""
-                )
-            );
+        std::string nextScreen;
+        if (itemJson["nextScreen"].is_number())
+        {
+            nextScreen = std::to_string(itemJson["nextScreen"].int_value());
+        }
+        else if (itemJson["nextScreen"].is_string())
+        {
+            nextScreen = itemJson["nextScreen"].string_value();
+        }
+        else
+        {
+            nextScreen.clear();
+        }
 
         screen->AddMenuItem(MenuItem(
             itemJson["name"].string_value()

--- a/src/ScreenManager.hpp
+++ b/src/ScreenManager.hpp
@@ -53,7 +53,7 @@ public:
 
 private:
     void GoToScreenPtr(ScreenBase *screen);
-    std::string ReadFileContents(const std::string &filepath) const;
+    static std::string ReadFileContents(const std::string &filepath);
 
     void BuildMenuScreenFromJSON(const json11::Json &screenJson);
 

--- a/src/Screens/ScreenBase.hpp
+++ b/src/Screens/ScreenBase.hpp
@@ -41,7 +41,6 @@ public:
             SetId(GetName());
     }
     
-    //virtual ~ScreenBase() { OnChangeFocus(false); };
     virtual ~ScreenBase() {};
 
     virtual void Render() {};

--- a/src/Screens/ScreenBase.hpp
+++ b/src/Screens/ScreenBase.hpp
@@ -40,7 +40,9 @@ public:
         if(GetId() == "")
             SetId(GetName());
     }
-    virtual ~ScreenBase() { OnChangeFocus(false); };
+    
+    //virtual ~ScreenBase() { OnChangeFocus(false); };
+    virtual ~ScreenBase() {};
 
     virtual void Render() {};
     virtual void handle_input_event(const InputDeviceType device_type, const struct input_event& event) = 0;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,6 +5,14 @@ project(CuckooTests CXX)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Enable ccache for faster test rebuilds
+find_program(CCACHE_FOUND ccache)
+if(CCACHE_FOUND)
+    set(CMAKE_CXX_COMPILER_LAUNCHER ccache)
+    set(CMAKE_C_COMPILER_LAUNCHER ccache)
+    message(STATUS "ccache found and enabled for test builds")
+endif()
+
 # Include FetchContent for downloading GoogleTest
 include(FetchContent)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,7 +37,6 @@ set(
     TEST_SOURCE_FILES
     ../src/ScreenManager.cpp
     ../src/ConfigurationReader.cpp
-    ../third-party/json11/json11.cpp
     ../src/HAL/Beeper.cpp
     ../src/HAL/BitmapFont.cpp
     ../src/HAL/Inputs.cpp
@@ -82,15 +81,14 @@ pkg_check_modules(CURL REQUIRED libcurl)
 # Add libcurl include directories for host compilation
 target_include_directories(cuckoo_tests PRIVATE ${CURL_INCLUDE_DIRS})
 
-# Add json11 include directory for tests
-target_include_directories(cuckoo_tests PRIVATE ../third-party/json11)
 target_include_directories(cuckoo_tests PRIVATE ${CMAKE_BINARY_DIR}/lvgl/src)
 
 target_link_directories(cuckoo_tests PRIVATE ${CMAKE_BINARY_DIR}/lvgl/src/lvgl-build/lib)
 
-# Link against GoogleTest libraries (including GMock) and system libcurl
+# Link against GoogleTest libraries (including GMock), json11, and system libcurl
 target_link_libraries(
     cuckoo_tests
+    json11
     gtest_main
     gtest
     gmock

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -81,7 +81,12 @@ pkg_check_modules(CURL REQUIRED libcurl)
 # Add libcurl include directories for host compilation
 target_include_directories(cuckoo_tests PRIVATE ${CURL_INCLUDE_DIRS})
 
+# Add LVGL include directories - need both the main include and parent for lv_conf.h relative path
 target_include_directories(cuckoo_tests PRIVATE ${CMAKE_BINARY_DIR}/lvgl/src)
+target_include_directories(cuckoo_tests PRIVATE ${CMAKE_SOURCE_DIR})
+
+# Add LV_CONF_PATH definition to match LVGL library build
+target_compile_definitions(cuckoo_tests PRIVATE LV_CONF_PATH="${CMAKE_SOURCE_DIR}/lv_conf.h")
 
 target_link_directories(cuckoo_tests PRIVATE ${CMAKE_BINARY_DIR}/lvgl/src/lvgl-build/lib)
 

--- a/tests/TestBackplateComms.cpp
+++ b/tests/TestBackplateComms.cpp
@@ -106,11 +106,11 @@ public:
 
     ~BackplateCommsExposed() override = default;
 
-    inline bool InitializeSerial() { return BackplateComms::InitializeSerial(); };
-    inline bool DoBurstStage() { return BackplateComms::DoBurstStage(); };
-    inline bool DoInfoGathering() { return BackplateComms::DoInfoGathering(); };
-    inline bool GetInfo(MessageType command, MessageType expectedResponse) { return BackplateComms::GetInfo(command, expectedResponse); };
-    inline void TaskBodyComms() { BackplateComms::TaskBodyComms(); };
+    bool InitializeSerial() { return BackplateComms::InitializeSerial(); };
+    bool DoBurstStage() { return BackplateComms::DoBurstStage(); };
+    bool DoInfoGathering() { return BackplateComms::DoInfoGathering(); };
+    bool GetInfo(MessageType command, MessageType expectedResponse) { return BackplateComms::GetInfo(command, expectedResponse); };
+    void TaskBodyComms() { BackplateComms::TaskBodyComms(); };
 
 };
 

--- a/tests/TestBackplateComms.cpp
+++ b/tests/TestBackplateComms.cpp
@@ -42,14 +42,14 @@ protected:
         // before the destructor).
     }
 
-    testing::Action<int(char*, int)> mockReadResponse(const std::vector<uint8_t>& responseBuffer) {
+    static testing::Action<int(char*, int)> mockReadResponse(const std::vector<uint8_t>& responseBuffer) {
         return testing::Invoke([responseBuffer](char* buffer, int bufferSize) {
             std::memcpy(buffer, responseBuffer.data(), responseBuffer.size());
             return static_cast<int>(responseBuffer.size());
         });
     }
 
-    testing::Action<int(timeval&)> mockGetTimeval(int sec, int usec) {
+    static testing::Action<int(timeval&)> mockGetTimeval(int sec, int usec) {
         return testing::Invoke([sec, usec](timeval& tv) {
             tv.tv_sec = sec;
             tv.tv_usec = usec;
@@ -57,7 +57,7 @@ protected:
         });
     }
 
-    testing::Action<int(timeval&)> mockGetTimevalSecs() {
+    static testing::Action<int(timeval&)> mockGetTimevalSecs() {
         return testing::Invoke([&](timeval& tv) {
             
             tv.tv_sec = mockCurrentTimeSec;
@@ -68,7 +68,7 @@ protected:
 
     MockSerialPort mockSerialPort;
     MockDateTimeProvider mockDateTimeProvider;
-    int mockCurrentTimeSec;
+    static int mockCurrentTimeSec;
 };
 
 class BackplateCommsExposed : public BackplateComms

--- a/tests/TestBackplateComms.cpp
+++ b/tests/TestBackplateComms.cpp
@@ -57,18 +57,41 @@ protected:
         });
     }
 
-    static testing::Action<int(timeval&)> mockGetTimevalSecs() {
-        return testing::Invoke([&](timeval& tv) {
-            
+    testing::Action<int(timeval&)> mockGetTimevalSecs() {
+        return testing::Invoke([this](timeval& tv) {
             tv.tv_sec = mockCurrentTimeSec;
             tv.tv_usec = 0;
             return 0;
         });
     }
 
+    std::function<void(float)> testTempCb = [this](float temp) {
+        s_tempCalled = true;
+        s_tempVal = temp;
+    };
+
+    std::function<void(int)> testPirCb = [this](int value) {
+        s_pirCalled = true;
+        s_pirVal = value;
+    };
+
+    std::function<void(uint16_t, const uint8_t*, size_t)> testGenericCb = [this](uint16_t type, const uint8_t* payload, size_t len) {
+        s_genericCalled = true;
+        s_genericType = type;
+        s_genericLen = len;
+    };
+
     MockSerialPort mockSerialPort;
     MockDateTimeProvider mockDateTimeProvider;
-    static int mockCurrentTimeSec;
+    int mockCurrentTimeSec;
+
+    bool s_tempCalled = false;
+    float s_tempVal = 0.0F;
+    bool s_pirCalled = false;
+    size_t s_pirVal = 0;
+    bool s_genericCalled = false;
+    uint16_t s_genericType = 0;
+    size_t s_genericLen = 0;
 };
 
 class BackplateCommsExposed : public BackplateComms
@@ -81,7 +104,7 @@ public:
     : BackplateComms(serialPort, dateTimeProvider)
     {};
 
-    virtual ~BackplateCommsExposed() = default;
+    ~BackplateCommsExposed() override = default;
 
     inline bool InitializeSerial() { return BackplateComms::InitializeSerial(); };
     inline bool DoBurstStage() { return BackplateComms::DoBurstStage(); };
@@ -348,34 +371,6 @@ TEST_F(TestBackplateComms, DoBurstStageHandlesAllMessagesInOneRead)
     EXPECT_TRUE(comms.DoBurstStage());
 }
 
-namespace {
-    static bool s_tempCalled = false;
-    static float s_tempVal = 0.0f;
-    static bool s_pirCalled = false;
-    static size_t s_pirVal = 0;
-    static bool s_genericCalled = false;
-    static uint16_t s_genericType = 0;
-    static size_t s_genericLen = 0;
-
-    void testTempCb(float temp)
-    {
-        s_tempCalled = true;
-        s_tempVal = temp;
-    }
-
-    void testPirCb(int value)
-    {
-        s_pirCalled = true;
-        s_pirVal = value;
-    }
-
-    void testGenericCb(uint16_t type, const uint8_t* payload, size_t len)
-    {
-        s_genericCalled = true;
-        s_genericType = type;
-        s_genericLen = len;
-    }
-}
 
 TEST_F(TestBackplateComms, TemperatureCallbackInvoked)
 {
@@ -393,12 +388,12 @@ TEST_F(TestBackplateComms, TemperatureCallbackInvoked)
     EXPECT_CALL(mockSerialPort, Read(_,_))
         .WillOnce(mockReadResponse(sensorMsg.GetRawMessage()));
 
-    s_tempCalled = false; s_genericCalled = false; s_genericType = 0; s_tempVal = 0.0f;
+    s_tempCalled = false; s_genericCalled = false; s_genericType = 0; s_tempVal = 0.0F;
     comms.TaskBodyComms();
 
     EXPECT_TRUE(s_tempCalled);
     // payload {0x11,0x22} -> temp_cc = 0x2211 = 8721 -> 87.21 C
-    EXPECT_NEAR(s_tempVal, 87.21f, 0.01f);
+    EXPECT_NEAR(s_tempVal, 87.21F, 0.01F);
 }
 
 TEST_F(TestBackplateComms, PIRCallbackInvoked)
@@ -439,7 +434,10 @@ TEST_F(TestBackplateComms, CallbacksNotInvokedOnBadCrc)
     auto raw = sensorMsg.GetRawMessage();
     // Corrupt last CRC byte
     std::vector<uint8_t> corrupted(raw.begin(), raw.end());
-    if (!corrupted.empty()) corrupted[corrupted.size()-1] ^= 0xFF;
+    if (!corrupted.empty())
+    {
+        corrupted[corrupted.size()-1] ^= 0xFF;
+    }
 
     EXPECT_CALL(mockSerialPort, Write(_)).WillRepeatedly(Return(1));
     EXPECT_CALL(mockSerialPort, Read(_,_))

--- a/tests/TestConfigurationReader.cpp
+++ b/tests/TestConfigurationReader.cpp
@@ -144,7 +144,7 @@ TEST_F(ConfigurationReaderTest, CompleteWorkflow) {
     ConfigurationReader config(test_config_filename_);
     
     // Load the configuration
-    bool loaded = config.load();
+    ASSERT_TRUE(config.load());
     
     // Test various getter methods
     std::string str_val = config.get_string("test_key", "default_string");
@@ -162,20 +162,19 @@ TEST_F(ConfigurationReaderTest, CompleteWorkflow) {
 // Test Home Assistant configuration methods
 TEST_F(ConfigurationReaderTest, HomeAssistantConfigWithValidData) {
     ConfigurationReader config(test_config_filename_);
-    config.load();
+    ASSERT_TRUE(config.load());
     
     // Test getting Home Assistant configuration
     std::string base_url = config.get_home_assistant_base_url("default_url");
     std::string token = config.get_home_assistant_token("default_token");
     std::string entity_id = config.get_home_assistant_entity_id("default_entity");
-    bool has_config = config.has_home_assistant_config();
+    ASSERT_TRUE(config.has_home_assistant_config());
     
     // With json11 working, these should return the actual values
     // If json11 isn't working, they'll return defaults
     EXPECT_TRUE(base_url == "http://test.local:8123" || base_url == "default_url");
     EXPECT_TRUE(token == "test_token_123" || token == "default_token");
     EXPECT_TRUE(entity_id == "switch.test_light" || entity_id == "default_entity");
-    // has_config might be true if json11 works, false otherwise
 }
 
 TEST_F(ConfigurationReaderTest, HomeAssistantConfigWithDefaults) {

--- a/tests/TestIntegrationContainer.cpp
+++ b/tests/TestIntegrationContainer.cpp
@@ -61,7 +61,7 @@ TEST_F(IntegrationContainerTest, LoadIntegrationsFromConfigLoadsHomeAssistantSwi
     ASSERT_NE(sw, nullptr);
     EXPECT_EQ(sw->GetId(), "1");
     EXPECT_EQ(sw->GetName(), "Test Switch 1");
-    HomeAssistantSwitch *haSw = dynamic_cast<HomeAssistantSwitch*>(sw);
+    auto *haSw = dynamic_cast<HomeAssistantSwitch*>(sw);
     EXPECT_NE(haSw, nullptr);
     EXPECT_EQ(haSw->GetEntityId(), "switch.test_switch_1");
 }

--- a/tests/TestMessageParser.cpp
+++ b/tests/TestMessageParser.cpp
@@ -81,7 +81,10 @@ TEST(TestMessageParser, BadCrcDoesNotProduceMessageButRecovers)
 
     // Create corrupted copy
     vector<uint8_t> bad(goodRaw.begin(), goodRaw.end());
-    if (!bad.empty()) bad[bad.size()-1] ^= 0xFF; // flip final CRC byte
+    if (!bad.empty()) 
+    {
+        bad[bad.size()-1] ^= 0xFF; // flip final CRC byte
+    }
 
     MessageParser parser;
     auto outBad = parser.Feed(bad.data(), bad.size());

--- a/tests/TestScreenManager.cpp
+++ b/tests/TestScreenManager.cpp
@@ -6,11 +6,11 @@
 // Mock screen class for testing
 class MockScreen : public ScreenBase {
 public:
-    MockScreen() : ScreenBase() {};
+    MockScreen() {};
     MockScreen(ScreenManager *sm, const json11::Json &js) : ScreenBase(sm, js) {};
-    virtual ~MockScreen() {};
+    ~MockScreen() override {};
 
-    void Render() {
+    void Render() override {
         renderCallCount++;
     }
 
@@ -18,7 +18,7 @@ public:
         return renderCallCount;
     }
 
-    void handle_input_event(const InputDeviceType device_type, const struct input_event& event) {
+    void handle_input_event(const InputDeviceType device_type, const struct input_event& event) override {
         // Mock implementation - do nothing for tests
     }
 
@@ -29,7 +29,7 @@ private:
 // Test fixture for ScreenManager tests
 class ScreenManagerTest : public ::testing::Test {
 protected:
-    void SetUp() {
+    void SetUp() override {
         screenManager = new ScreenManager(nullptr, nullptr, nullptr);
         auto json = json11::Json();
         mockScreen1 = new MockScreen(screenManager, json);
@@ -41,7 +41,7 @@ protected:
         screenManager->AddScreen(std::unique_ptr<ScreenBase>(mockScreen2));
     }
     
-    void TearDown() {
+    void TearDown() override {
         delete screenManager;
         screenManager = nullptr;
     }
@@ -96,7 +96,7 @@ TEST_F(ScreenManagerTest, Destructor)
     screenManager->GoToNextScreen(mockScreen2->GetId());
     
     // Create a new ScreenManager and delete it to test destructor
-    ScreenManager* test_manager = new ScreenManager(nullptr, nullptr, nullptr);
+    auto *test_manager = new ScreenManager(nullptr, nullptr, nullptr);
     delete test_manager;
     
     SUCCEED();
@@ -104,7 +104,7 @@ TEST_F(ScreenManagerTest, Destructor)
 
 TEST_F(ScreenManagerTest, ThreeLevelScreenHistory) 
 {
-    MockScreen* mock_screen3 = new MockScreen();
+    auto *mock_screen3 = new MockScreen();
     mock_screen3->SetId("3");
     screenManager->AddScreen(std::unique_ptr<ScreenBase>(mock_screen3));
 

--- a/tests/TestScreenManagerConfigLoad.cpp
+++ b/tests/TestScreenManagerConfigLoad.cpp
@@ -78,7 +78,7 @@ TEST_F(ScreenManagerConfigLoadTest, HomeScreenLinksToMenuScreen) {
     ASSERT_NE(nullptr, home_screen);
 
     // Check that HomeScreen's next screen is MenuScreen
-    HomeScreen* hs = dynamic_cast<HomeScreen*>(home_screen);
+    auto *hs = dynamic_cast<HomeScreen*>(home_screen);
     ASSERT_NE(hs, nullptr);
 
     EXPECT_EQ("2", hs->GetNextScreenId());
@@ -181,7 +181,7 @@ TEST_F(ScreenManagerConfigLoadTest, MenuScreenItemsLoaded) {
 
     ScreenBase* menu_screen = screen_manager->GetScreenById("1");
     ASSERT_NE(nullptr, menu_screen);
-    MenuScreen* ms = dynamic_cast<MenuScreen*>(menu_screen);
+    auto *ms = dynamic_cast<MenuScreen*>(menu_screen);
     ASSERT_NE(ms, nullptr);
     EXPECT_EQ(3, ms->CountMenuItems());
 
@@ -206,7 +206,7 @@ TEST_F(ScreenManagerConfigLoadTest, SwitchScreenIntegrationLoaded) {
 
     ScreenBase* switch_screen = screen_manager->GetScreenById("1");
     ASSERT_NE(nullptr, switch_screen);
-    SwitchScreen* ss = dynamic_cast<SwitchScreen*>(switch_screen);
+    auto *ss = dynamic_cast<SwitchScreen*>(switch_screen);
     ASSERT_NE(ss, nullptr);
     EXPECT_EQ("42", ss->GetIntegrationId());
 }
@@ -230,7 +230,7 @@ TEST_F(ScreenManagerConfigLoadTest, DimmerScreenIntegrationLoaded) {
 
     ScreenBase* dimmer_screen = screen_manager->GetScreenById("1");
     ASSERT_NE(nullptr, dimmer_screen);
-    DimmerScreen* ds = dynamic_cast<DimmerScreen*>(dimmer_screen);
+    auto *ds = dynamic_cast<DimmerScreen*>(dimmer_screen);
     ASSERT_NE(ds, nullptr);
     EXPECT_EQ("55", ds->GetIntegrationId());
 }


### PR DESCRIPTION
Support for clang-tidy has been added and enabled by default.

Fixed a raft of errors that where raised by `clang-tidy`

Support for `ccache` has been added to speed up builds. Developers need to have installed this to take advantage.

Created `BUILD_GUIDE.md`, explaining some of the new build options.

`json11` is now pulled in as an external project. The source was never modified so there was no need track in the project

Fixed some build issues that resulted from the changes.